### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/tgbot.py
+++ b/tgbot.py
@@ -155,7 +155,7 @@ def download_subtitle_file(url: str, lang: str, title: str, chat_id: int, timed:
 def cmd_start(message):
     bot.reply_to(message, TEXT_START)
 
-@bot.message_handler(func=lambda m: m.text and (m.text.startswith("http") or (urlparse(m.text).hostname and urlparse(m.text).hostname.endswith("tiktok.com"))))
+@bot.message_handler(func=lambda m: m.text and (m.text.startswith("http") or (urlparse(m.text).hostname and (urlparse(m.text).hostname == "tiktok.com" or urlparse(m.text).hostname.endswith(".tiktok.com")))))
 def handle_link(message):
     uid = message.from_user.id
     chat = message.chat.id


### PR DESCRIPTION
Potential fix for [https://github.com/XZY123lol/getytvideo-tg-dvla/security/code-scanning/4](https://github.com/XZY123lol/getytvideo-tg-dvla/security/code-scanning/4)

To fix the issue, we need to ensure that the URL's hostname is properly validated to belong to the legitimate `tiktok.com` domain, including its subdomains. The safest approach is to check if the hostname matches `tiktok.com` or ends with `.tiktok.com` (to allow subdomains). This can be achieved using `urlparse` to extract the hostname and then performing a strict validation.

**Steps to fix:**
1. Parse the URL using `urlparse` to extract the hostname.
2. Check if the hostname matches `tiktok.com` or ends with `.tiktok.com`.
3. Replace the current `endswith` check with this stricter validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
